### PR TITLE
【修复】消除函数atol()隐含声明的警告

### DIFF
--- a/ulog_easyflash_be.c
+++ b/ulog_easyflash_be.c
@@ -29,6 +29,7 @@
 #include <rtthread.h>
 #include <easyflash.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define LOG_TAG              "easyflash"
 #include <ulog.h>


### PR DESCRIPTION
测试平台：
rt-thread V4.1.1
mdk V5.31.0.0
ArmClang V6.14