### PR TITLE
消除未定义atol的警告

### DIFF
--- a/ulog_easyflash_be.c
+++ b/ulog_easyflash_be.c
@@ -185,6 +185,7 @@ INIT_APP_EXPORT(ulog_ef_backend_init);
 
 #if defined(RT_USING_FINSH) && defined(FINSH_USING_MSH)
 #include <finsh.h>
+#include <stdlib.h>
 static void ulog_flash(uint8_t argc, char **argv)
 {
     if (argc >= 2)


### PR DESCRIPTION
[消除未定义atol的警告](warning: implicit declaration of function 'atol' [-Wimplicit-function-declaration])